### PR TITLE
Filter GitHub code search results by word boundary matches

### DIFF
--- a/content/ida/plugins/activity/2026/07/13.md
+++ b/content/ida/plugins/activity/2026/07/13.md
@@ -7,15 +7,11 @@ draft: false
 # IDA Plugin Updates on 2026-07-13
 
 ### New Releases:
-  - [christian-doctrine](https://github.com/ebenezer-isaac/christian-doctrine) [v0.1.0](https://github.com/ebenezer-isaac/christian-doctrine/releases/tag/v0.1.0)
   - [Spectra](https://github.com/alicangnll/Spectra) [1.2.8](https://github.com/alicangnll/Spectra/releases/tag/1.2.8)
 
 ### Activity:
   - [augur](https://github.com/0xdea/augur)
     - [d524797b](https://github.com/0xdea/augur/commit/d524797b1a4efaab9db6efa99a7af00d29dc6f9d): chore: update deps and lint allowlist
-  - [christian-doctrine](https://github.com/ebenezer-isaac/christian-doctrine)
-    - [f1f982e3](https://github.com/ebenezer-isaac/christian-doctrine/commit/f1f982e3407da73b3b83dac1bc0f3322bff66a28): fix(deploy): auto-restart engine stacks on reboot (restart: unless-st…
-    - [8618ff92](https://github.com/ebenezer-isaac/christian-doctrine/commit/8618ff92782f8c0882eba0ad02a94a89bea75cb4): feat: companion web+mobile app, engine on VPS, doctrine PDF archive
   - [CTF-Tools](https://github.com/bernie6401/CTF-Tools)
     - [a6a81ac5](https://github.com/bernie6401/CTF-Tools/commit/a6a81ac5af4ea9f666fae7ae07e549e570568dab): Add webshell files for remote command execution
   - [disrobe](https://github.com/1-3-7/disrobe)

--- a/tools/github-ida-plugins/fetch-github-ida-plugins.py
+++ b/tools/github-ida-plugins/fetch-github-ida-plugins.py
@@ -13,6 +13,7 @@
 #
 # requires env variable GITHUB_TOKEN to be set.
 import os
+import re
 import json
 import logging
 import requests
@@ -311,10 +312,15 @@ def handle_rate_limit_response(response: requests.Response, attempt: int = 1) ->
 
 
 def search_github_code(token: str, query: str, limit: int | None = None) -> list[dict]:
-    """Search GitHub code using REST API directly with rate limit handling."""
+    """Search GitHub code using REST API directly with rate limit handling.
+
+    Requests the text-match media type so each result carries `text_matches`
+    fragments showing where the query matched. We use those fragments to reject
+    substring false positives (see `result_has_genuine_match`).
+    """
     headers = {
         "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github.v3+json"
+        "Accept": "application/vnd.github.text-match+json"
     }
     
     results = []
@@ -387,22 +393,31 @@ def collect_search_results(token: str, limit: int | None = None) -> list[SearchR
 
     logger.info("After HexRays repository: %d unique repositories", len(results))
 
-    # Define search configurations for GitHub code search
+    # Define search configurations for GitHub code search.
+    #
+    # GitHub code search matches query tokens as substrings, so e.g. "ida_domain"
+    # also matches inside unrelated identifiers like "louw_nida_domain". Each config
+    # carries a `validator` regex that must match one of the returned text-match
+    # fragments at a word boundary, which rejects those false positives while
+    # keeping genuine hits (e.g. `import ida_domain`, `from ida_domain import ...`).
     search_configs = [
         {
             'query': 'language:python AND "def PLUGIN_ENTRY()" AND in:file',
             'language': 'python',
-            'description': 'Python IDA plugins'
+            'description': 'Python IDA plugins',
+            'validator': re.compile(r"\bPLUGIN_ENTRY\b"),
         },
         {
             'query': '"idaapi init" AND in:file AND language:"C++"',
             'language': 'C++',
-            'description': 'C++ IDA plugins'
+            'description': 'C++ IDA plugins',
+            'validator': re.compile(r"\bidaapi\b"),
         },
         {
             'query': 'language:python AND "ida_domain" AND in:file',
             'language': 'python',
-            'description': 'Python files with ida_domain'
+            'description': 'Python files with ida_domain',
+            'validator': re.compile(r"\bida_domain\b"),
         }
     ]
 
@@ -411,6 +426,7 @@ def collect_search_results(token: str, limit: int | None = None) -> list[SearchR
         query = config['query']
         language = config['language']
         description = config['description']
+        validator = config['validator']
 
         logger.info("%s query: %s", description, query)
 
@@ -423,6 +439,15 @@ def collect_search_results(token: str, limit: int | None = None) -> list[SearchR
 
             # Apply filtering logic
             if should_skip_result(repo_name, file_path, result["html_url"]):
+                continue
+
+            # Reject substring false positives (e.g. "ida_domain" inside
+            # "louw_nida_domain") by requiring a genuine word-boundary match.
+            if not result_has_genuine_match(result, validator):
+                logger.info(
+                    "skipping %s (%s): %r not found at a word boundary (substring false positive)",
+                    repo_name, file_path, validator.pattern,
+                )
                 continue
 
             # Skip if we already have this repo from another source
@@ -441,6 +466,26 @@ def collect_search_results(token: str, limit: int | None = None) -> list[SearchR
 
     logger.info("Total unique repositories collected: %d", len(results))
     return results
+
+
+def result_has_genuine_match(result: dict, validator: "re.Pattern[str]") -> bool:
+    """Confirm a code search hit contains a real, word-boundary-delimited token.
+
+    GitHub code search matches query tokens as substrings, so a query for
+    ``ida_domain`` also returns files that merely contain it inside a larger
+    identifier such as ``louw_nida_domain`` (unrelated to IDA). We requested the
+    text-match media type, so each result carries ``text_matches`` fragments
+    showing the matched regions; we re-check those locally with a word-boundary
+    regex to drop the false positives.
+
+    Returns True when no text-match fragments are available, so that a missing
+    field never silently drops a legitimate plugin.
+    """
+    text_matches = result.get("text_matches")
+    if not text_matches:
+        return True
+
+    return any(validator.search(tm.get("fragment", "")) for tm in text_matches)
 
 
 def should_skip_result(repo_name: str, file_path: str, html_url: str) -> bool:


### PR DESCRIPTION
## Summary
Improve the accuracy of GitHub code search result filtering by validating that query matches occur at word boundaries, not just as substrings. This eliminates false positives where search terms appear inside unrelated identifiers.

## Key Changes
- **Add regex validation to search results**: Each search configuration now includes a `validator` regex pattern that checks for word-boundary-delimited matches
- **Request text-match media type**: Changed the GitHub API Accept header from `application/vnd.github.v3+json` to `application/vnd.github.text-match+json` to receive `text_matches` fragments showing where queries matched
- **Implement `result_has_genuine_match()` function**: New validation function that checks returned text-match fragments against the word-boundary regex to confirm legitimate matches and reject substring false positives
- **Add filtering logic**: Search results are now filtered through the validator before being added to results, with debug logging for rejected matches
- **Update search configurations**: Added validator patterns for:
  - `PLUGIN_ENTRY` (Python plugins)
  - `idaapi` (C++ plugins)  
  - `ida_domain` (Python files)

## Implementation Details
The solution addresses a limitation in GitHub's code search where queries match substrings anywhere in identifiers. For example, a search for `ida_domain` would incorrectly match `louw_nida_domain`. By requesting the text-match media type and validating matches locally with word-boundary regexes, we can confidently distinguish genuine matches from false positives while maintaining a safe fallback (returning True when text_matches are unavailable).

https://claude.ai/code/session_01QVf2zGXLnhMkekH6YUziKN