### PR TITLE
Add Quarkslab's blog to RSS subscriptions

### DIFF
--- a/content/follows/williballenthin.opml
+++ b/content/follows/williballenthin.opml
@@ -280,6 +280,8 @@
                 xmlUrl="https://hnrss.org/newcomments?q=ida+pro"
                 />
 
+            <outline type="rss" text="Quarkslab's blog" title="Quarkslab's blog" xmlUrl="https://blog.quarkslab.com/feeds/all.atom.xml" htmlUrl="https://blog.quarkslab.com/"/>
+
             <!--
             <outline type="rss"
                 text="" title=""

--- a/content/follows/williballenthin.opml
+++ b/content/follows/williballenthin.opml
@@ -280,7 +280,11 @@
                 xmlUrl="https://hnrss.org/newcomments?q=ida+pro"
                 />
 
-            <outline type="rss" text="Quarkslab's blog" title="Quarkslab's blog" xmlUrl="https://blog.quarkslab.com/feeds/all.atom.xml" htmlUrl="https://blog.quarkslab.com/"/>
+            <outline type="rss"
+                text="Quarkslab's blog" title="Quarkslab's blog"
+                htmlUrl="https://blog.quarkslab.com/"
+                xmlUrl="https://blog.quarkslab.com/feeds/all.atom.xml"
+                />
 
             <!--
             <outline type="rss"

--- a/content/posts/2024-06-11-rss-subscriptions/williballenthin-quiet.opml
+++ b/content/posts/2024-06-11-rss-subscriptions/williballenthin-quiet.opml
@@ -62,6 +62,7 @@
             <outline type="rss" text="The Mad Ned Memo" title="The Mad Ned Memo" xmlUrl="https://madned.substack.com/feed/" htmlUrl="https://madned.substack.com"/>
             <outline type="rss" text="Valtetu" title="Valtetu" xmlUrl="https://valtetu.framer.website/blog/rss.xml" htmlUrl="https://valtetu.framer.website/blog"/>
             <outline type="rss" text="Rock or Ager" title="Rock or Ager" xmlUrl="https://rockorager.dev/feed.xml" htmlUrl="https://rockorager.dev/log/"/>
+            <outline type="rss" text="Quarkslab's blog" title="Quarkslab's blog" xmlUrl="https://blog.quarkslab.com/feeds/all.atom.xml" htmlUrl="https://blog.quarkslab.com/"/>
         </outline>
     </body>
 </opml>


### PR DESCRIPTION
## Summary
Added Quarkslab's blog to the RSS feed subscriptions in two OPML files.

## Changes
- Added Quarkslab's blog feed (`https://blog.quarkslab.com/feeds/all.atom.xml`) to the main follows list in `williballenthin.opml`
- Added the same feed to the quiet subscriptions list in `williballenthin-quiet.opml`

## Details
Both entries include the feed URL, HTML URL, and proper OPML outline formatting with text and title attributes set to "Quarkslab's blog".

https://claude.ai/code/session_017oqWuNRDqriqDJwcJvHjJk